### PR TITLE
Added hooks for scripts and styles in layouts, bugfixed multilanguage support

### DIFF
--- a/AdminModule/presenters/BasePresenter.php
+++ b/AdminModule/presenters/BasePresenter.php
@@ -215,6 +215,9 @@ class BasePresenter extends \WebCMS2\Common\BasePresenter
             case 'textarea':
                 $form->addTextArea($ident, $setting->getKey())->setDefaultValue($setting->getValue())->setAttribute('class', 'editor');
                 break;
+            case 'textarea-plain':
+                $form->addTextArea($ident, $setting->getKey())->setDefaultValue($setting->getValue());
+                break;
             case 'radio':
                 $form->addRadioList($ident, $setting->getKey(), $setting->getOptions())->setDefaultValue($setting->getValue());
                 break;
@@ -223,6 +226,9 @@ class BasePresenter extends \WebCMS2\Common\BasePresenter
                 break;
             case 'checkbox':
                 $form->addCheckbox($ident, $setting->getKey())->setDefaultValue($setting->getValue());
+                break;
+            case 'checkbox-toggle':
+                $form->addCheckbox($ident, $setting->getKey())->setDefaultValue($setting->getValue())->setAttribute('data-toggle', 'toggle');
                 break;
             default:
                 $form->addText($ident, $setting->getKey())->setDefaultValue($setting->getValue())->setAttribute('class', 'form-control');

--- a/AdminModule/presenters/BasePresenter.php
+++ b/AdminModule/presenters/BasePresenter.php
@@ -210,28 +210,35 @@ class BasePresenter extends \WebCMS2\Common\BasePresenter
 
     private function createFormElement($form, $setting)
     {
-        $ident = $setting->getId();
+        if (!is_null($setting->getLanguage())) {
+            $ident = $this->em->getRepository('WebCMS\Entity\Setting')->findOneBy(array(
+                'key' => $setting->getKey(),
+                'language' => $this->state->language->getId()
+            ));
+        } else {
+            $ident = $setting;
+        }
         switch ($setting->getType()) {
             case 'textarea':
-                $form->addTextArea($ident, $setting->getKey())->setDefaultValue($setting->getValue())->setAttribute('class', 'editor');
+                $form->addTextArea($ident->getId(), $setting->getKey())->setDefaultValue($ident->getValue())->setAttribute('class', 'editor');
                 break;
             case 'textarea-plain':
-                $form->addTextArea($ident, $setting->getKey())->setDefaultValue($setting->getValue());
+                $form->addTextArea($ident->getId(), $setting->getKey())->setDefaultValue($ident->getValue());
                 break;
             case 'radio':
-                $form->addRadioList($ident, $setting->getKey(), $setting->getOptions())->setDefaultValue($setting->getValue());
+                $form->addRadioList($ident->getId(), $setting->getKey(), $setting->getOptions())->setDefaultValue($ident->getValue());
                 break;
             case 'select':
-                $form->addSelect($ident, $setting->getKey(), $setting->getOptions())->setDefaultValue($setting->getValue());
+                $form->addSelect($ident->getId(), $setting->getKey(), $setting->getOptions())->setDefaultValue($ident->getValue());
                 break;
             case 'checkbox':
-                $form->addCheckbox($ident, $setting->getKey())->setDefaultValue($setting->getValue());
+                $form->addCheckbox($ident->getId(), $setting->getKey())->setDefaultValue($ident->getValue());
                 break;
             case 'checkbox-toggle':
-                $form->addCheckbox($ident, $setting->getKey())->setDefaultValue($setting->getValue())->setAttribute('data-toggle', 'toggle');
+                $form->addCheckbox($ident->getId(), $setting->getKey())->setDefaultValue($ident->getValue())->setAttribute('data-toggle', 'toggle');
                 break;
             default:
-                $form->addText($ident, $setting->getKey())->setDefaultValue($setting->getValue())->setAttribute('class', 'form-control');
+                $form->addText($ident->getId(), $setting->getKey())->setDefaultValue($ident->getValue())->setAttribute('class', 'form-control');
                 break;
         }
 
@@ -242,13 +249,13 @@ class BasePresenter extends \WebCMS2\Common\BasePresenter
     {
         $values = $form->getValues();
 
-        foreach ($values as $key => $v) {
-            $setting = $this->em->find('WebCMS\Entity\Setting', $key);
+        foreach ($values as $id => $v) {
+            $setting = $this->em->find('WebCMS\Entity\Setting', $id);
             $setting->setValue($v);
         }
 
         $this->em->flush();
-
+       
         $this->flashMessage('Settings has been saved.', 'success');
         $this->forward('this');
     }

--- a/AdminModule/presenters/SettingsPresenter.php
+++ b/AdminModule/presenters/SettingsPresenter.php
@@ -482,6 +482,40 @@ class SettingsPresenter extends \AdminModule\BasePresenter
         return $this->createSettingsForm($settings);
     }
 
+    /* SCRIPTS SETTINGS */
+
+    public function renderStylesSettings()
+    {
+        $this->reloadContent();
+
+        $globalStylesVars = array('pageStylesHead');
+        $hooks = array();
+
+        foreach (Finder::findFiles('@*.latte')->in(APP_DIR . '/templates') as $key => $file) {
+            $filename = $file->getFileName();
+
+            foreach ($globalStylesVars as $key => $var) {
+                if (\WebCMS\Helpers\SystemHelper::checkFileContainsStr(APP_DIR . '/templates/' . $filename, $var)) {
+                    $hooks[$filename][$var] = true;
+                } else {
+                    $hooks[$filename][$var] = false;
+                }
+            }
+        }
+
+        $this->template->stylesHooks = $hooks;
+    }
+
+    public function createComponentStylesGlobalForm()
+    {
+        $settings = array();
+
+        $settings[] = $this->settings->get('Styles head', \WebCMS\Settings::SECTION_BASIC, 'textarea-plain');
+        $settings[] = $this->settings->get('Enable styles head', \WebCMS\Settings::SECTION_BASIC, 'checkbox-toggle');
+
+        return $this->createSettingsForm($settings);
+    }
+
     /* PROJECT SPECIFIC SETTINGS */
 
     public function createComponentProjectSettingsForm()

--- a/AdminModule/presenters/SettingsPresenter.php
+++ b/AdminModule/presenters/SettingsPresenter.php
@@ -2,6 +2,8 @@
 
 namespace AdminModule;
 
+use Nette\Utils\Finder;
+
 /**
  * Settings presenter.
  * @author Tomáš Voslař <tomas.voslar at webcook.cz>
@@ -440,6 +442,44 @@ class SettingsPresenter extends \AdminModule\BasePresenter
 
         $this->flashMessage('Seo has been updated.', 'success');
         $this->invalidateControl('flashMessages');
+    }
+
+    /* SCRIPTS SETTINGS */
+
+    public function renderScriptsSettings()
+    {
+        $this->reloadContent();
+
+        $globalScriptsVars = array('pageScriptsHead', 'pageScriptsBodyStart', 'pageScriptsBodyEnd');
+        $hooks = array();
+
+        foreach (Finder::findFiles('@*.latte')->in(APP_DIR . '/templates') as $key => $file) {
+            $filename = $file->getFileName();
+
+            foreach ($globalScriptsVars as $key => $var) {
+                if (\WebCMS\Helpers\SystemHelper::checkFileContainsStr(APP_DIR . '/templates/' . $filename, $var)) {
+                    $hooks[$filename][$var] = true;
+                } else {
+                    $hooks[$filename][$var] = false;
+                }
+            }
+        }
+
+        $this->template->scriptsHooks = $hooks;
+    }
+
+    public function createComponentScriptsGlobalForm()
+    {
+        $settings = array();
+
+        $settings[] = $this->settings->get('Scripts head', \WebCMS\Settings::SECTION_BASIC, 'textarea-plain');
+        $settings[] = $this->settings->get('Enable scripts head', \WebCMS\Settings::SECTION_BASIC, 'checkbox-toggle');
+        $settings[] = $this->settings->get('Scripts body start', \WebCMS\Settings::SECTION_BASIC, 'textarea-plain');
+        $settings[] = $this->settings->get('Enable scripts body start', \WebCMS\Settings::SECTION_BASIC, 'checkbox-toggle');
+        $settings[] = $this->settings->get('Scripts body end', \WebCMS\Settings::SECTION_BASIC, 'textarea-plain');
+        $settings[] = $this->settings->get('Enable scripts body end', \WebCMS\Settings::SECTION_BASIC, 'checkbox-toggle');
+
+        return $this->createSettingsForm($settings);
     }
 
     /* PROJECT SPECIFIC SETTINGS */

--- a/AdminModule/presenters/SettingsPresenter.php
+++ b/AdminModule/presenters/SettingsPresenter.php
@@ -482,7 +482,7 @@ class SettingsPresenter extends \AdminModule\BasePresenter
         return $this->createSettingsForm($settings);
     }
 
-    /* SCRIPTS SETTINGS */
+    /* STYLES SETTINGS */
 
     public function renderStylesSettings()
     {

--- a/AdminModule/templates/@layout.latte
+++ b/AdminModule/templates/@layout.latte
@@ -29,6 +29,7 @@
 
 		<link rel="stylesheet" media="screen" href="{$basePath}/admin-client/bootstrap/dist/css/bootstrap.min.css" type="text/css">
 		<link rel="stylesheet" media="screen" href="{$basePath}/admin-client/bootstrap-tour/build/css/bootstrap-tour.min.css" type="text/css">
+		<link rel="stylesheet" media="screen" href="{$basePath}/admin-client/bootstrap-toggle/css/bootstrap-toggle.min.css" type="text/css">
 
 		<link rel="stylesheet" media="screen,projection,tv" href="{$basePath}/admin-client/webcms2/css/screen.css" type="text/css">
 		<link rel="stylesheet" media="print" href="{$basePath}/admin-client/webcms2/css/print.css" type="text/css">
@@ -206,6 +207,7 @@
 		<script type="text/javascript" src="{$basePath}/admin-client/kendo-ui/js/kendo.web.min.js"></script>
 		<script type="text/javascript" src="{$basePath}/admin-client/bootstrap/dist/js/bootstrap.min.js"></script>
 		<script type="text/javascript" src="{$basePath}/admin-client/bootstrap-tour/build/js/bootstrap-tour.min.js"></script>
+		<script type="text/javascript" src="{$basePath}/admin-client/bootstrap-toggle/js/bootstrap-toggle.min.js"></script>
 		<script type="text/javascript" src="{$basePath}/admin-client/bootbox/bootbox.js"></script>
 		<script type="text/javascript" src="{$basePath}/admin-client/grido/client-side/grido.js"></script>
 		<script type="text/javascript" src="{$basePath}/admin-client/nette.ajax.js/nette.ajax.js"></script>

--- a/AdminModule/templates/Settings/scriptsSettings.latte
+++ b/AdminModule/templates/Settings/scriptsSettings.latte
@@ -1,0 +1,72 @@
+{block content}
+<div class="page-heading">
+	<h1>{_'Scripts settings'}</h1>
+	{include 'tabs.latte' active => 'scripts'}
+</div>
+<div class="well">
+
+<div class="alert alert-info">
+	{_'Layout hooks presence overview. Only hooks installed in all of your layout files should be activated unless you know exactly what you are doing.'}
+</div>
+
+<table class="table table-bordered table-hover">
+    <thead>
+        <tr>
+            <th>{_'Layout filename'}</th>
+            {foreach $scriptsHooks as $layout => $hooks}
+            	{first}<th n:foreach="$hooks as $name => $status">{$name}</th>{/first}
+            {/foreach}
+        </tr>
+    </thead>
+    <tbody>
+        <tr n:foreach="$scriptsHooks as $layoutName => $hooks">
+            <td>{$layoutName}</td>
+            {foreach $hooks as $name => $status}
+            	{if $status === TRUE}
+	        		<td class="success" data-hook="{$name}" data-status="1">
+            		{_"INSTALLED"}
+            	{else}
+            		<td class="danger" data-hook="{$name}" data-status="0">
+            		{_"MISSING"}
+            	{/if}
+            </td>
+            {/foreach}
+        </tr>
+    </tbody>
+</table>
+
+<div id="jq_hooks_info" class="hidden" n:syntax="off">
+	<strong>Please, ensure that all of your layout files are containing following declarations:</strong>
+	<ul>
+		<li>{ifset $pageScriptsHead}{!$pageScriptsHead}{/ifset} - should be placed right after the opening &lt;head&gt; tag</li>
+		<li>{ifset $pageScriptsBodyStart}{!$pageScriptsBodyStart}{/ifset} - should be placed right after the opening &lt;body&gt; tag</li>
+		<li>{ifset $pageScriptsBodyEnd}{!$pageScriptsBodyEnd}{/ifset} - should be placed right in front of the closing &lt;/body&gt; tag</li>
+	</ul>
+</div>
+
+<br />
+
+<div class="alert alert-info">
+	{_'Following values are global settings for scripts inserted inside <head></head>, directly after <body> and directly in front of </body> tags.'}
+</div>
+
+{control scriptsGlobalForm}
+
+<br />
+
+<div class="alert alert-info">
+	{_'You can override global settings or add more custom scripts in the Scripts settings tab of any specific page.'}
+</div>
+
+</div><!-- /.well -->
+<script>
+	$(document).ready( function(){
+		$("input[data-toggle='toggle']").bootstrapToggle(); //TODO: move this into Webcms.main.js
+
+		if ($("td[data-status=0]").attr('data-hook')) {
+			$('#jq_hooks_info').removeClass('hidden');
+		}
+	});
+</script>
+
+{/block}

--- a/AdminModule/templates/Settings/seoSettings.latte
+++ b/AdminModule/templates/Settings/seoSettings.latte
@@ -1,6 +1,6 @@
 {block content}
 <div class="page-heading">
-	<h1>{_'Boxes settings'}</h1>
+	<h1>{_'SEO settings'}</h1>
 	{include 'tabs.latte' active => 'seo'}
 </div>
 <div class="well">

--- a/AdminModule/templates/Settings/stylesSettings.latte
+++ b/AdminModule/templates/Settings/stylesSettings.latte
@@ -1,7 +1,7 @@
 {block content}
 <div class="page-heading">
-	<h1>{_'Scripts settings'}</h1>
-	{include 'tabs.latte' active => 'scripts'}
+	<h1>{_'Styles settings'}</h1>
+	{include 'tabs.latte' active => 'styles'}
 </div>
 <div class="well">
 
@@ -13,13 +13,13 @@
     <thead>
         <tr>
             <th>{_'Layout filename'}</th>
-            {foreach $scriptsHooks as $layout => $hooks}
+            {foreach $stylesHooks as $layout => $hooks}
             	{first}<th n:foreach="$hooks as $name => $status">{$name}</th>{/first}
             {/foreach}
         </tr>
     </thead>
     <tbody>
-        <tr n:foreach="$scriptsHooks as $layoutName => $hooks">
+        <tr n:foreach="$stylesHooks as $layoutName => $hooks">
             <td>{$layoutName}</td>
             {foreach $hooks as $name => $status}
             	{if $status === TRUE}
@@ -38,24 +38,22 @@
 <div id="jq_hooks_info" class="hidden" n:syntax="off">
 	<strong>Please, ensure that all of your layout files are containing following declarations:</strong>
 	<ul>
-		<li>{include $pageScriptsHead} - should be placed right after the opening &lt;head&gt; tag</li>
-		<li>{include $pageScriptsBodyStart} - should be placed right after the opening &lt;body&gt; tag</li>
-		<li>{include $pageScriptsBodyEnd} - should be placed right in front of the closing &lt;/body&gt; tag</li>
+		<li>{include $pageStylesHead} - should be placed right after the scripts inside of the &lt;head&gt;&lt;/head&gt;</li>
 	</ul>
 </div>
 
 <br />
 
 <div class="alert alert-info">
-	{_'Following values are global settings for scripts inserted inside <head></head>, directly after <body> and directly in front of </body> tags.'}
+	{_'Following value is global setting for styles inserted inside <head></head>.'}
 </div>
 
-{control scriptsGlobalForm}
+{control stylesGlobalForm}
 
 <br />
 
 <div class="alert alert-info">
-	{_'You can override global settings or add more custom scripts in the Scripts settings tab of any specific page.'}
+	{_'You can override global settings or add more custom styles in the Styles settings tab of any specific page.'}
 </div>
 
 </div><!-- /.well -->

--- a/AdminModule/templates/Settings/tabs.latte
+++ b/AdminModule/templates/Settings/tabs.latte
@@ -4,6 +4,8 @@
   <li {if $active == "emails"}class="active"{/if}><a class="ajax" id="tEmails" n:href="Settings:emails">{_'Emails settings'}</a></li>
   <li {if $active == "boxes"}class="active"{/if}><a class="ajax" id="tBoxes" n:href="Settings:boxesSettings">{_'Boxes settings'}</a></li>
   <li {if $active == "seo"}class="active"{/if}><a class="ajax" id="tSeo" n:href="Settings:seoSettings">{_'Seo settings'}</a></li>
+  <li {if $active == "scripts"}class="active"{/if}><a class="ajax" id="tScripts" n:href="Settings:scriptsSettings">{_'Scripts settings'}</a></li>
+  <li {if $active == "styles"}class="active"{/if}><a class="ajax" id="tStyles" n:href="Settings:stylesSettings">{_'Styles settings'}</a></li>
   <li {if $active == "api"}class="active"{/if}><a class="ajax" id="tApi" n:href="Settings:api">{_'API'}</a></li>
   <li {if $active == "project"}class="active"{/if}><a class="ajax" id="tProject" n:href="Settings:project">{_'Project specific settings'}</a></li>
 </ul>

--- a/Common/BasePresenter.php
+++ b/Common/BasePresenter.php
@@ -40,7 +40,7 @@ abstract class BasePresenter extends \Nette\Application\UI\Presenter
      */
     protected function getSettings()
     {
-        $query = $this->em->createQuery('SELECT s FROM WebCMS\Entity\Setting s WHERE s.language >= '.$this->getLanguageId().' OR s.language IS NULL');
+        $query = $this->em->createQuery('SELECT s FROM WebCMS\Entity\Setting s WHERE s.language = '.$this->getLanguageId().' OR s.language IS NULL');
         $tmp = $query->getResult();
 
         $settings = array();

--- a/FrontendModule/presenters/BasePresenter.php
+++ b/FrontendModule/presenters/BasePresenter.php
@@ -74,6 +74,10 @@ class BasePresenter extends \WebCMS2\Common\BasePresenter
         // set up boxes
         $this->setUpBoxes();
 
+        // load user defined scripts & styles
+        $this->setPageScripts();
+        $this->setPageStyles();
+
         // set default seo settings
         if (is_object($this->actualPage)) {
             $this->template->breadcrumb = $this->getBreadcrumbs();
@@ -123,6 +127,30 @@ class BasePresenter extends \WebCMS2\Common\BasePresenter
         } else {
             $this->template->seoTitle = $this->template->seoTitle.$this->settings->get('Seo title', \WebCMS\Settings::SECTION_BASIC, 'text')->getValue();
         }
+    }
+
+    private function setPageScripts()
+    {
+        $globalHead = $this->settings->get('Enable scripts head', \WebCMS\Settings::SECTION_BASIC, 'checkbox-toggle')->getValue();
+        $globalBodyStart = $this->settings->get('Enable scripts body start', \WebCMS\Settings::SECTION_BASIC, 'checkbox-toggle')->getValue();
+        $globalBodyEnd = $this->settings->get('Enable scripts body end', \WebCMS\Settings::SECTION_BASIC, 'checkbox-toggle')->getValue();
+
+        if ($globalHead) {
+            $this->template->pageScriptsHead = $this->settings->get('Scripts head', \WebCMS\Settings::SECTION_BASIC, 'textarea-plain')->getValue();
+        }
+
+        if ($globalBodyStart) {
+            $this->template->pageScriptsBodyStart = $this->settings->get('Scripts body start', \WebCMS\Settings::SECTION_BASIC, 'textarea-plain')->getValue();
+        }
+
+        if ($globalBodyEnd) {
+            $this->template->pageScriptsBodyEnd = $this->settings->get('Scripts body end', \WebCMS\Settings::SECTION_BASIC, 'textarea-plain')->getValue();
+        }
+    }
+
+    private function setPageStyles()
+    {
+
     }
 
     /* Startup method. */

--- a/FrontendModule/presenters/BasePresenter.php
+++ b/FrontendModule/presenters/BasePresenter.php
@@ -136,21 +136,39 @@ class BasePresenter extends \WebCMS2\Common\BasePresenter
         $globalBodyEnd = $this->settings->get('Enable scripts body end', \WebCMS\Settings::SECTION_BASIC, 'checkbox-toggle')->getValue();
 
         if ($globalHead) {
-            $this->template->pageScriptsHead = $this->settings->get('Scripts head', \WebCMS\Settings::SECTION_BASIC, 'textarea-plain')->getValue();
+            $pageScriptsHead = $this->settings->get('Scripts head', \WebCMS\Settings::SECTION_BASIC, 'textarea-plain')->getValue();
+        } else {
+            $pageScriptsHead = '';
         }
 
         if ($globalBodyStart) {
-            $this->template->pageScriptsBodyStart = $this->settings->get('Scripts body start', \WebCMS\Settings::SECTION_BASIC, 'textarea-plain')->getValue();
+            $pageScriptsBodyStart = $this->settings->get('Scripts body start', \WebCMS\Settings::SECTION_BASIC, 'textarea-plain')->getValue();
+        } else {
+            $pageScriptsBodyStart = '';
         }
 
         if ($globalBodyEnd) {
-            $this->template->pageScriptsBodyEnd = $this->settings->get('Scripts body end', \WebCMS\Settings::SECTION_BASIC, 'textarea-plain')->getValue();
+            $pageScriptsBodyEnd = $this->settings->get('Scripts body end', \WebCMS\Settings::SECTION_BASIC, 'textarea-plain')->getValue();
+        } else {
+            $pageScriptsBodyEnd = '';
         }
+
+        $this->template->pageScriptsHead = $this->createTemplate('Nette\Templating\Template')->setSource($pageScriptsHead);
+        $this->template->pageScriptsBodyStart = $this->createTemplate('Nette\Templating\Template')->setSource($pageScriptsBodyStart);
+        $this->template->pageScriptsBodyEnd = $this->createTemplate('Nette\Templating\Template')->setSource($pageScriptsBodyEnd);
     }
 
     private function setPageStyles()
     {
+        $globalStylesHead = $this->settings->get('Enable styles head', \WebCMS\Settings::SECTION_BASIC, 'checkbox-toggle')->getValue();
 
+        if ($globalStylesHead) {
+            $pageStylesHead = $this->settings->get('Styles head', \WebCMS\Settings::SECTION_BASIC, 'textarea-plain')->getValue();
+        } else {
+            $pageStylesHead = '';
+        }
+
+        $this->template->pageStylesHead = $this->createTemplate('Nette\Templating\Template')->setSource($pageStylesHead);
     }
 
     /* Startup method. */

--- a/libs/helpers/SystemHelper.php
+++ b/libs/helpers/SystemHelper.php
@@ -99,6 +99,25 @@ class SystemHelper
     }
 
     /**
+     * Check if given file contains given string
+     * @param  String $filename
+     * @param  String $needle
+     * @return Boolean
+     */
+    public static function checkFileContainsStr($filename, $needle)
+    {
+        if (file_exists($filename)) {
+            $content = file_get_contents($filename);
+
+            if (strstr($content, $needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      *
      * @param type $user
      * @param type $permission


### PR DESCRIPTION
Scripts and styles can be inserted dynamically into the layouts from the administration section.
Bugfixed settings saving and retrieving in different language modes.
Added new form elements - textarea-plain (without editor), checkbox-toggle (swipe-to-toggle)